### PR TITLE
publish single object/action pair and track everything

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,8 @@
                         onLogin(response);
                     }, {scope: 'publish_actions'});
                     // TODO: JIT permission request?
+
+                    trackEvent(TRACK_LOGIN_LANDING, 1);
                 }
             });
         };


### PR DESCRIPTION
changeset
---

- create a single `connection` object (viewable to default post perms user gives us) with fun? information describing the nature of the connection; teases other potential users of app?
- create a single `suggest` action that is viewable to creator and tagged users
- add tracking. note that FB tracking only works in a full/prod FB canvas app environment. track the following:
    - user pre-login landing
    - pass/fail of login
    - multi-friend-select render complete
    - pass/fail of create connection
    - pass/fail of create suggestion
